### PR TITLE
Bring the plugin back alive to a working state

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -34,5 +34,4 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -x $i"
 done
 
-echo "open -u $PLUGIN_USERNAME,XXXXXX $PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"
-lftp -c "open -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"
+lftp -c "open ftp://$PLUGIN_USERNAME:$FTP_PASSWORD@$PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"

--- a/upload.sh
+++ b/upload.sh
@@ -34,4 +34,5 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -x $i"
 done
 
+echo "open -u $PLUGIN_USERNAME,XXXXXX $PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"
 lftp -c "open -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"

--- a/upload.sh
+++ b/upload.sh
@@ -34,4 +34,4 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -x $i"
 done
 
-lftp -c "open ftp://$PLUGIN_USERNAME:$FTP_PASSWORD@$PLUGIN_HOSTNAME; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR"
+lftp -e "set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME

--- a/upload.sh
+++ b/upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$PLUGIN_USERNAME" ]; then
+if [ -z "$FTP_USERNAME" ]; then
     echo "Need to set username"
     exit 1
 fi
@@ -34,4 +34,4 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -x $i"
 done
 
-lftp -e "set xfer:log 1; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME
+lftp -e "set xfer:log 1; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" -u $FTP_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME

--- a/upload.sh
+++ b/upload.sh
@@ -34,4 +34,4 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -x $i"
 done
 
-lftp -e "set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME
+lftp -e "set xfer:log 1; set ftp:ssl-force $PLUGIN_SECURE; set ftp:ssl-protect-data $PLUGIN_SECURE; mirror -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" -u $PLUGIN_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME


### PR DESCRIPTION
Previously the plugin has failed to deploy giving each time a "unknown command" with the hostname as error output. This PR solves that issue by using another command syntax which was tested carefully to work with FTP and FTPS servers.

I also moved the username option to be a secret instead, to increase the security and minimize a possible bruteforce attack by just hitting the server with a known username.