### PR TITLE
Fix chmod error message after file transferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ pipeline:
     secrets: [ ftp_username, ftp_password ]
     secure: true (default) | false # true = use FTP(S), false = FTP without SSL
     verify: true (default) | false # true = strong SSL verification, false = supress SSL verification error
+    chmod: true (default) | false # true = chmod after file transferred, false = no chmod after file transferred
     dest_dir: /var/www/mysite
     src_dir: /mysite/static
     exclude:

--- a/upload.sh
+++ b/upload.sh
@@ -44,5 +44,5 @@ lftp -e "set xfer:log 1; \
   set ftp:ssl-protect-data $PLUGIN_SECURE; \
   set ssl:verify-certificate $PLUGIN_VERIFY; \
   set ssl:check-hostname $PLUGIN_VERIFY; \
-  mirror --verbose -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
+  mirror --verbose -p -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
   -u $FTP_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME

--- a/upload.sh
+++ b/upload.sh
@@ -26,6 +26,12 @@ if [ -z "$PLUGIN_SRC_DIR" ]; then
     PLUGIN_SRC_DIR="/"
 fi
 
+if [ -z "$PLUGIN_CHMOD" ]; then
+    PLUGIN_CHMOD=""
+else
+    PLUGIN_CHMOD="-p"
+fi
+
 PLUGIN_EXCLUDE_STR=""
 PLUGIN_INCLUDE_STR=""
 
@@ -44,5 +50,5 @@ lftp -e "set xfer:log 1; \
   set ftp:ssl-protect-data $PLUGIN_SECURE; \
   set ssl:verify-certificate $PLUGIN_VERIFY; \
   set ssl:check-hostname $PLUGIN_VERIFY; \
-  mirror --verbose -p -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
+  mirror --verbose $PLUGIN_CHMOD -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
   -u $FTP_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME

--- a/upload.sh
+++ b/upload.sh
@@ -29,7 +29,10 @@ fi
 if [ -z "$PLUGIN_CHMOD" ]; then
     PLUGIN_CHMOD=""
 else
-    PLUGIN_CHMOD="-p"
+    if [ "$PLUGIN_CHMOD" = true ]; then
+        PLUGIN_CHMOD="-p"
+    else
+        PLUGIN_CHMOD=""
 fi
 
 PLUGIN_EXCLUDE_STR=""

--- a/upload.sh
+++ b/upload.sh
@@ -33,6 +33,7 @@ else
         PLUGIN_CHMOD="-p"
     else
         PLUGIN_CHMOD=""
+    fi
 fi
 
 PLUGIN_EXCLUDE_STR=""

--- a/upload.sh
+++ b/upload.sh
@@ -30,9 +30,9 @@ if [ -z "$PLUGIN_CHMOD" ]; then
     PLUGIN_CHMOD=""
 else
     if [ "$PLUGIN_CHMOD" = true ]; then
-        PLUGIN_CHMOD="-p"
-    else
         PLUGIN_CHMOD=""
+    else
+        PLUGIN_CHMOD="-p"
     fi
 fi
 


### PR DESCRIPTION
The is a bug fix for #7 

I add parameter PLUGIN_CHMOD for specifying whether ```-p``` is needed or not