### PR TITLE
Fix PLUGIN_EXCLUDE and PLUGIN_INCLUDE

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -43,11 +43,11 @@ PLUGIN_INCLUDE_STR=""
 
 IFS=',' read -ra in_arr <<< "$PLUGIN_EXCLUDE"
 for i in "${in_arr[@]}"; do
-    PLUGIN_EXCLUDE_STR="$PLUGIN_EXCLUDE_STR -x $i"
+    PLUGIN_EXCLUDE_STR="$PLUGIN_EXCLUDE_STR -x '$i'"
 done
 IFS=',' read -ra in_arr <<< "$PLUGIN_INCLUDE"
 for i in "${in_arr[@]}"; do
-    PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -i $i"
+    PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -i '$i'"
 done
 
 lftp -e "set xfer:log 1; \


### PR DESCRIPTION
For use regexp in include/exclude, it is needed to surround the expresion sent to lftp in single quotes

With this fix, you can config your include/exclude setting with a regexp, for example:

```
PLUGIN_EXCLUDE: ^(\..+|bbdd/|deploy/|nbproject/|composer.+|phpdoc\.xml|sonar-project\.properties)$
```

In my example, I ignore:
- All hidden files
- bbdd, deploy and nbproject folders
- composer* files
- phpdoc.xml file
- sonar-project.properties files

Without this fix, the following error occurs:
```
mirror: regular expression `^(\..+': Unmatched ( or \(
```




