### PR TITLE
Custom mirror opts

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -43,11 +43,11 @@ PLUGIN_INCLUDE_STR=""
 
 IFS=',' read -ra in_arr <<< "$PLUGIN_EXCLUDE"
 for i in "${in_arr[@]}"; do
-    PLUGIN_EXCLUDE_STR="$PLUGIN_EXCLUDE_STR -x $i"
+    PLUGIN_EXCLUDE_STR="$PLUGIN_EXCLUDE_STR -x '$i'"
 done
 IFS=',' read -ra in_arr <<< "$PLUGIN_INCLUDE"
 for i in "${in_arr[@]}"; do
-    PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -i $i"
+    PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -i '$i'"
 done
 
 lftp -e "set xfer:log 1; \

--- a/upload.sh
+++ b/upload.sh
@@ -58,5 +58,5 @@ lftp -e "set xfer:log 1; \
   set ssl:check-hostname $PLUGIN_VERIFY; \
   set net:max-retries 3; \
   $PLUGIN_CLEAN_DIR; \
-  mirror --verbose $PLUGIN_CHMOD -R $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
+  mirror --verbose $PLUGIN_CHMOD -R $PLUGIN_MIRROR_OPTS $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR" \
   -u $FTP_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME


### PR DESCRIPTION
Simple plugin option to pass options to mirror, for example:

```
      PLUGIN_MIRROR_OPTS: -Rn --ignore-time --upload-older --no-symlinks
```

These options are added to default options created by the plugin