### PR TITLE
Add debug option, SSH auto confirm fingerprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:edge
 
 RUN apk --no-cache add \
+        openssh \
         libressl \
         lftp \
         bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ environment:
     PLUGIN_VERIFY: false
     PLUGIN_EXCLUDE: (egrep like pattern matching)
     PLUGIN_INCLUDE: (egrep like pattern matching)
+    PLUGIN_CHMOD: true | false (default true)
+    PLUGIN_CLEAN_DIR: true | false (default false)
+    PLUGIN_AUTO_CONFIRM: true | false (default false)
+    PLUGIN_DEBUG: true | false (default false)
 ```
 
 ## Full file example

--- a/upload.sh
+++ b/upload.sh
@@ -38,6 +38,18 @@ else
     PLUGIN_CLEAN_DIR=""
 fi
 
+if [ -z "$PLUGIN_DEBUG" ]; then
+    PLUGIN_DEBUG=""
+else
+    PLUGIN_DEBUG="-d"
+fi
+
+if [ -n "$PLUGIN_AUTO_CONFIRM" ]; then
+    PLUGIN_AUTO_CONFIRM="true"
+else
+    PLUGIN_AUTO_CONFIRM="false"
+fi
+
 PLUGIN_EXCLUDE_STR=""
 PLUGIN_INCLUDE_STR=""
 
@@ -50,10 +62,11 @@ for i in "${in_arr[@]}"; do
     PLUGIN_INCLUDE_STR="$PLUGIN_INCLUDE_STR -i '$i'"
 done
 
-lftp -e "set xfer:log 1; \
+lftp $PLUGIN_DEBUG -e "set xfer:log 1; \
   set ftp:ssl-allow $PLUGIN_SECURE; \
   set ftp:ssl-force $PLUGIN_SECURE; \
   set ftp:ssl-protect-data $PLUGIN_SECURE; \
+  set sftp:auto-confirm $PLUGIN_AUTO_CONFIRM; \
   set ssl:verify-certificate $PLUGIN_VERIFY; \
   set ssl:check-hostname $PLUGIN_VERIFY; \
   set net:max-retries 3; \


### PR DESCRIPTION
This PR fixes #25

It allows to specify `PLUGIN_DEBUG` which adds the -d flag. This is very helpful if the plugin does not work for some reason.

Furthermore it adds `PLUGIN_AUTO_CONFIRM` which answers the `Are you sure you want to continue connecting (yes/no/[fingerprint])?` automatically with `yes`.

And finally I added the new `PLUGIN_DEBUG` `PLUGIN_AUTO_CONFIRM` as well as two mission options `PLUGIN_CHMOD` `PLUGIN_CLEAN_DIR` to the README.

