### PR TITLE
New Parameter PLUGIN_SSH_ACCEPT_RSA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apk --no-cache add \
         bash
 
 ADD upload.sh /bin/
-RUN chmod +x /bin/upload.sh
+RUN chmod +x /bin/upload.sh && mkdir ~/.ssh && chmod 700 ~/.ssh
 
 ENTRYPOINT /bin/upload.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ environment:
     PLUGIN_CHMOD: true | false (default true)
     PLUGIN_CLEAN_DIR: true | false (default false)
     PLUGIN_AUTO_CONFIRM: true | false (default false)
+    PLUGIN_SSH_ACCEPT_RSA: true | false (default false)
     PLUGIN_DEBUG: true | false (default false)
 ```
 

--- a/upload.sh
+++ b/upload.sh
@@ -50,6 +50,10 @@ else
     PLUGIN_AUTO_CONFIRM="false"
 fi
 
+if [ "$PLUGIN_SSH_ACCEPT_RSA" = true ]; then
+  echo "HostKeyAlgorithms ssh-rsa" > ~/.ssh/config && echo "PubkeyAcceptedKeyTypes ssh-rsa" >> ~/.ssh/config && chmod 600 ~/.ssh/config
+fi;
+
 PLUGIN_EXCLUDE_STR=""
 PLUGIN_INCLUDE_STR=""
 


### PR DESCRIPTION
OpenSSH disabled RSA signatures using SHA-1 hashes. [See release notes](https://www.openssh.com/releasenotes.html)
> Potentially-incompatible changes
>
> This release disables RSA signatures using the SHA-1 hash algorithm
> by default. This change has been made as the SHA-1 hash algorithm is
> cryptographically broken, and it is possible to create chosen-prefix
> hash collisions for <USD$50K [1]

If your hosting provider still uses the old server keys, the sftp connection cannot be established.
The process fails with `mirror: Fatal error: max-retries exceeded`
The new parameter PLUGIN_SSH_ACCEPT_RSA changes the configuration of SSH to accept RSA keys with SHA-1 hashes.