### PR TITLE
Only transfer newer files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ environment:
     PLUGIN_INCLUDE: (egrep like pattern matching)
     PLUGIN_CHMOD: true | false (default true)
     PLUGIN_CLEAN_DIR: true | false (default false)
+    PLUGIN_ONLY_NEWER: true | false (default false)
     PLUGIN_AUTO_CONFIRM: true | false (default false)
     PLUGIN_SSH_ACCEPT_RSA: true | false (default false)
     PLUGIN_PRE_ACTION: string (default empty)
@@ -44,13 +45,22 @@ The `PLUGIN_PRE_ACTION` is executed *before* the `PLUGIN_CLEAN_DIR` (if set).
 The `PLUGIN_POST_ACTION` is executed *after* the ftp "mirror" operation.  
 
 Multiple Actions can be set, they need to be divided by a semicolon `;` .  
-**Example:**  
+#### Example:
 There is another project's folder ("project2") in a subfolder in the destination directory. We need to move this folder to a temporary location and restore it after the upload completed.
 ```yaml
 PLUGIN_CLEAN_DIR: true
 PLUGIN_PRE_ACTION: mv /dest/project2 /temp/project2;
 PLUGIN_POST_ACTION: mv /temp/project2 /dest/project2;
 ```
+
+### Transfer only newer files
+The setting `PLUGIN_ONLY_NEWER: true` (only transfer newer files) does not mix well with the `PLUGIN_CLEAN_DIR: true` (clean destination directory before transfer).
+
+When setting `PLUGIN_ONLY_NEWER: true` parameter to true, make sure to _exclude_ any files/folders that are not present in the source directory, but should be kept on the server.  
+#### Example:
+Source folder does not contain an `.env` file, it exists on the remote server and should be kept.  
+Also, we do not want to transfer the source's `.git` folder and `.gitignore` file:  
+Set `PLUGIN_ONLY_NEWER: true` and `PLUGIN_EXCLUDE: ^\.git/$,^\.gitignore$,^\.env$` environment variables.
 
 ## Full file example
 

--- a/upload.sh
+++ b/upload.sh
@@ -32,6 +32,12 @@ else
     PLUGIN_CHMOD=""
 fi
 
+if [ "$PLUGIN_ONLY_NEWER" = true ]; then
+    PLUGIN_ONLY_NEWER="-e -n --ignore-time"
+else
+    PLUGIN_ONLY_NEWER=""
+fi
+
 if [ "$PLUGIN_CLEAN_DIR" = true ]; then
     PLUGIN_CLEAN_DIR="rm -r $PLUGIN_DEST_DIR"
 else
@@ -76,6 +82,6 @@ lftp $PLUGIN_DEBUG -e "set xfer:log 1; \
   set net:max-retries 3; \
   $PLUGIN_PRE_ACTION; \
   $PLUGIN_CLEAN_DIR; \
-  mirror --verbose $PLUGIN_CHMOD -R $PLUGIN_MIRROR_OPTS $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR; \
+  mirror --verbose $PLUGIN_CHMOD -R $PLUGIN_ONLY_NEWER $PLUGIN_MIRROR_OPTS $PLUGIN_INCLUDE_STR $PLUGIN_EXCLUDE_STR $(pwd)$PLUGIN_SRC_DIR $PLUGIN_DEST_DIR; \
   $PLUGIN_POST_ACTION;" \
   -u $FTP_USERNAME,$FTP_PASSWORD $PLUGIN_HOSTNAME


### PR DESCRIPTION
If the new parameter `PLUGIN_ONLY_NEWER` is set to `true`, only changed/newer files are transferred to the destination directory (closing #12 and #13 ).
Any files/folders not present in the source directory will be removed from the destination (closing #24 ).
If you need to keep certain files in the destination, add them as an `PLUGIN_EXCLUDE` . (also documented in README.md)

I have been using this script for several weeks now, cutting the deployment time of one of my projects from 5 minutes to 12 seconds 🚀